### PR TITLE
Fix php-fpm 5.6 path.

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -36,7 +36,7 @@ RUN apk update \
 COPY config/php/php.ini /etc/phpconf.d/50-setting.ini
 COPY config/php/php-fpm.conf /etc/php/php-fpm.conf
 
-CMD ["/usr/sbin/php-fpm", "-R", "--nodaemonize"]
+CMD ["/usr/bin/php-fpm", "-R", "--nodaemonize"]
 
 EXPOSE 9000
 


### PR DESCRIPTION
When runs the alpine-php:5.6 container, it throws:

`docker: Error response from daemon: oci runtime error: exec: "/usr/sbin/php-fpm": stat /usr/sbin/php-fpm: no such file or directory.`
