### PR TITLE
Prevent tini warning.

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -39,7 +39,7 @@ RUN apk update \
 COPY config/php/php.ini /etc/phpconf.d/50-setting.ini
 COPY config/php/php-fpm.conf /etc/php/php-fpm.conf
 
-ENTRYPOINT ["/usr/bin/tini", "--"]
+ENTRYPOINT ["/sbin/tini", "--"]
 
 CMD ["/usr/bin/php-fpm", "-R", "--nodaemonize"]
 

--- a/5.6/config/php/php-fpm.conf
+++ b/5.6/config/php/php-fpm.conf
@@ -1,6 +1,6 @@
 [www]
-user = root
-group = root
+user = nobody
+group = nobody
 listen = [::]:9000
 chdir = /app
 
@@ -12,13 +12,13 @@ pm.max_spare_servers = 10
 pm.max_requests = 300
 
 listen.backlog = -1
-rlimit_files = 131072
+rlimit_files = 65536
 rlimit_core = unlimited
 catch_workers_output = yes
 
-emergency_restart_threshold 10
-emergency_restart_interval 1m
-process_control_timeout 10
+emergency_restart_threshold = 10
+emergency_restart_interval = 1m
+process_control_timeout = 10
 
 request_slowlog_timeout = 5s
 request_terminate_timeout = 120s

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -38,7 +38,7 @@ RUN apk add --update \
 COPY config/php/php.ini /etc/php7conf.d/50-setting.ini
 COPY config/php/php-fpm.conf /etc/php7/php-fpm.conf
 
-ENTRYPOINT ["/usr/bin/tini", "--"]
+ENTRYPOINT ["/sbin/tini", "--"]
 
 CMD ["/usr/sbin/php-fpm7", "-R", "--nodaemonize"]
 

--- a/7/config/php/php-fpm.conf
+++ b/7/config/php/php-fpm.conf
@@ -1,6 +1,12 @@
+[global]
+emergency_restart_threshold = 10
+emergency_restart_interval = 1m
+process_control_timeout = 10
+
+
 [www]
-user = root
-group = root
+user = nobody
+group = nobody
 listen = [::]:9000
 chdir = /app
 
@@ -12,13 +18,9 @@ pm.max_spare_servers = 10
 pm.max_requests = 300
 
 listen.backlog = -1
-rlimit_files = 131072
+rlimit_files = 65536
 rlimit_core = unlimited
 catch_workers_output = yes
-
-emergency_restart_threshold 10
-emergency_restart_interval 1m
-process_control_timeout 10
 
 request_slowlog_timeout = 5s
 request_terminate_timeout = 120s


### PR DESCRIPTION
When you try **docker run**, it show the next message:

> WARNING: Tini has been relocated to /sbin/tini.
> Please update your scripts to use /sbin/tini going forward.
> /usr/bin/tini has been preserved for backwards compatibility in Alpine 3.4,
> but WILL BE REMOVED in Alpine 3.5.
>
> [FATAL tini (6)] Executing child process '-p' failed: 'No such file or directory'

and exit de container.