### PR TITLE
Add php7-mysqli module.

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -16,6 +16,7 @@ RUN apk add --update \
     php7-intl \
     php7-json \
     php7-libsodium \
+    php7-mysqli \
     php7-mbstring \
     php7-opcache \
     php7-openssl \


### PR DESCRIPTION
Required module for WordPress sites.