### PR TITLE
Remove packages that are missing from PHP 7.2.

### DIFF
--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -16,7 +16,6 @@ RUN apk --update add ca-certificates \
     php7-common@cast \
     php7-apcu@cast \
     php7-bcmath@cast \
-    php7-xmlwriter@cast \
     php7-ctype@cast \
     php7-curl@cast \
     php7-exif@cast \
@@ -35,8 +34,6 @@ RUN apk --update add ca-certificates \
     php7-posix@cast \
     php7-session@cast \
     php7-xml@cast \
-    php7-simplexml@cast \
-    php7-mcrypt@cast \
     php7-xsl@cast \
     php7-zip@cast \
     php7-zlib@cast \
@@ -44,7 +41,6 @@ RUN apk --update add ca-certificates \
     php7-redis@cast \
     php7-fpm@cast \
     php7-sodium@cast \
-    php7-tokenizer@cast \
 
     && ln -s /usr/bin/php7 /usr/bin/php \
     && rm -rf /var/cache/apk/*


### PR DESCRIPTION
When using your image with any tag of PHP7.2 and executing php was giving me the following message: 
```
PHP Warning:  PHP Startup: Unable to load dynamic library 'mcrypt.so' (tried: /usr/lib/php7/modules/mcrypt.so (Error relocating /usr/lib/php7/modules/mcrypt.so: spprintf: symbol not found), /usr/lib/php7/modules/mcrypt.so.so (Error loading shared library /usr/lib/php7/modules/mcrypt.so.so: No such file or directory)) in Unknown on line 0
PHP Warning:  PHP Startup: Unable to load dynamic library 'simplexml.so' (tried: /usr/lib/php7/modules/simplexml.so (Error relocating /usr/lib/php7/modules/simplexml.so: spl_ce_Countable: symbol not found), /usr/lib/php7/modules/simplexml.so.so (Error loading shared library /usr/lib/php7/modules/simplexml.so.so: No such file or directory)) in Unknown on line 0
PHP Warning:  PHP Startup: tokenizer: Unable to initialize module
Module compiled with module API=20160303
PHP    compiled with module API=20170718
These options need to match
 in Unknown on line 0
PHP Warning:  PHP Startup: xmlwriter: Unable to initialize module
Module compiled with module API=20160303
PHP    compiled with module API=20170718
These options need to match
 in Unknown on line 0
PHP Warning:  PHP Startup: Unable to load dynamic library 'mcrypt.so' (tried: /usr/lib/php7/modules/mcrypt.so (Error relocating /usr/lib/php7/modules/mcrypt.so: spprintf: symbol not found), /usr/lib/php7/modules/mcrypt.so.so (Error loading shared library /usr/lib/php7/modules/mcrypt.so.so: No such file or directory)) in Unknown on line 0
PHP Warning:  PHP Startup: Unable to load dynamic library 'simplexml.so' (tried: /usr/lib/php7/modules/simplexml.so (Error relocating /usr/lib/php7/modules/simplexml.so: spl_ce_Countable: symbol not found), /usr/lib/php7/modules/simplexml.so.so (Error loading shared library /usr/lib/php7/modules/simplexml.so.so: No such file or directory)) in Unknown on line 0
PHP Warning:  PHP Startup: tokenizer: Unable to initialize module
Module compiled with module API=20160303
PHP    compiled with module API=20170718
These options need to match
 in Unknown on line 0
PHP Warning:  PHP Startup: xmlwriter: Unable to initialize module
Module compiled with module API=20160303
PHP    compiled with module API=20170718
These options need to match
 in Unknown on line 0
```

The Dockerfile has some packages that aren't present on PHP7.2 . I removed the following packages:

- mcrypt
- simplexml
- xmlwriter
- tokenizer