### PR TITLE
Supervisord user

### DIFF
--- a/7.1/devfs/etc/supervisor/conf.d/supervisord.conf
+++ b/7.1/devfs/etc/supervisor/conf.d/supervisord.conf
@@ -4,6 +4,7 @@ logfile=/var/log/supervisord.log
 pidfile=/var/run/supervisord.pid
 
 loglevel=debug
+user=root
 
 [program:fpm]
 command=/usr/sbin/php-fpm7 -R --nodaemonize

--- a/7.2/devfs/etc/supervisor/conf.d/supervisord.conf
+++ b/7.2/devfs/etc/supervisor/conf.d/supervisord.conf
@@ -4,6 +4,7 @@ logfile=/var/log/supervisord.log
 pidfile=/var/run/supervisord.pid
 
 loglevel=debug
+user=root
 
 [program:fpm]
 command=/usr/sbin/php-fpm7 -R --nodaemonize

--- a/7.3/devfs/etc/supervisor/conf.d/supervisord.conf
+++ b/7.3/devfs/etc/supervisor/conf.d/supervisord.conf
@@ -4,6 +4,7 @@ logfile=/var/log/supervisord.log
 pidfile=/var/run/supervisord.pid
 
 loglevel=debug
+user=root
 
 [program:fpm]
 command=/usr/sbin/php-fpm7 -R --nodaemonize

--- a/7.4/devfs/etc/supervisord/conf.d/supervisord.conf
+++ b/7.4/devfs/etc/supervisord/conf.d/supervisord.conf
@@ -4,6 +4,7 @@ logfile=/var/log/supervisord.log
 pidfile=/var/run/supervisord.pid
 
 loglevel=debug
+user=root
 
 [program:fpm]
 command=/usr/sbin/php-fpm7 -R --nodaemonize


### PR DESCRIPTION
```
php_1            | 2020-06-06 20:39:08,619 CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.
```