### PR TITLE
Update Dockerfile

### DIFF
--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -2,7 +2,10 @@ FROM alpine:3.15 as main
 
 LABEL maintainer="Jorge Arco <jorge.arcoma@gmail.com>"
 
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ --allow-untrusted gnu-libiconv \
+RUN apk --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/edge/community add \
+    # Current packages don't exist in other repositories
+        libavif \
+    && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ --allow-untrusted gnu-libiconv \
     # Packages
     tini \
     php81 \


### PR DESCRIPTION
Without libavif assembly crashes with error
ERROR: unable to select packages:
  so:libavif.so.13 (no such package):
    required by: php81-gd-8.1.2-r2[so:libavif.so.13]